### PR TITLE
Ops docs lambda route53 cloudfront

### DIFF
--- a/Ops/Ops-lessons-2022/AWS.md
+++ b/Ops/Ops-lessons-2022/AWS.md
@@ -27,6 +27,35 @@
 
 ### Lambda
 
+Lambda Resources:
+
+- Used to execute self contained pieces of code (functions) without a server
+- Billed for when it's in use rather then a dedicated server
+  - Examples of dedicated servers: ECS, EC2, Elastic Beanstalk
+- Multiple ways to execute a Lambda Function:
+  - API Endpoint
+  - Cron Job
+  - CloudWatch EventBridge
+- VPCs can be configured
+- Cannot be dockerized in the production environment
+- Can configure ARNs for authentication
+- Serverless framework can be used for local development
+
+SecurEd Use Cases:
+
+- Used to perform functionality that is not core to our system
+  - Example: Downloads Test - Tests the downloads of various objects in different statuses and reports errors to MongoDB
+- Fargate is being used more then Lambda
+  - Most core functionality that were implemented as Lambda have become Fargate instances
+
+Documentation:
+
+- [AWS Lambda](https://docs.aws.amazon.com/lambda/)
+- [Cron Jobs and Lambda](https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html)
+- [CloudWatch Events and Lambda](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/RunLambdaSchedule.html)
+- [Authenicator ARNs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html)
+- [Serverless Framework](https://www.serverless.com/)
+
 ### Cloudwatch
 
 ### EventBridge

--- a/Ops/Ops-lessons-2022/AWS.md
+++ b/Ops/Ops-lessons-2022/AWS.md
@@ -46,7 +46,7 @@ SecurEd Use Cases:
 - Used to perform functionality that is not core to our system
   - Example: Downloads Test - Tests the downloads of various objects in different statuses and reports errors to MongoDB
 - Fargate is being used more then Lambda
-  - Most core functionality that were implemented as Lambda have become Fargate instances
+  - Most core functionality that were implemented in Lambda have become Fargate instances
 
 Documentation:
 

--- a/Ops/Ops-lessons-2022/AWS.md
+++ b/Ops/Ops-lessons-2022/AWS.md
@@ -97,6 +97,19 @@ Documentation:
 
 ### CloudFront (CF)
 
+CloudFront Resources:
 
+- Accelerate static website content delivery
+- Serve video on demand or live streaming video
+- Encrypt specific fields throughout system processing
+- Serve private content
 
+SecurEd Use Cases:
 
+- Speed up loading our static sites
+  - Example: clark.press, standard guidelines client, CARD client
+
+Documentation:
+
+- [CloudFront Use Cases](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/IntroductionUseCases.html)
+- [AWS CloudFront](https://docs.aws.amazon.com/cloudfront/)

--- a/Ops/Ops-lessons-2022/AWS.md
+++ b/Ops/Ops-lessons-2022/AWS.md
@@ -72,6 +72,25 @@ Documentation:
 
 ### Route53
 
+Route 53 Resources:
+
+- Register new domains to an IP
+- Register new subdomains to an IP
+- Setup various applications like email and google workspace
+
+SecurEd Use Cases:
+
+- Deploying a new app under a different domain
+- Setting up Google Workspace
+- Setting up Emails
+- Deploying a new app under a subdomain
+- All SecurEd services deployed use Route 53
+
+Documentation:
+
+- [AWS Route 53](https://aws.amazon.com/route53/)
+- [DNS Record Types](https://www.cloudflare.com/learning/dns/dns-records/)
+
 ### Certificate Manager
 
 ### API Gateway


### PR DESCRIPTION
This PR adds the Lambda, Route 53, and CloudFront sections to the ops documentation.  Partially completes story [6921/ops-course-aws-lesson-documentation](https://app.shortcut.com/clarkcan/story/6921/ops-course-aws-lesson-documentation).